### PR TITLE
AUT-8441 Fix for enter key behavior during domain discovery on login form

### DIFF
--- a/theme/pages/authorization/login/scripts.tmpl
+++ b/theme/pages/authorization/login/scripts.tmpl
@@ -207,6 +207,14 @@
       usernameInput.disabled = false;
     });
 
+    usernameInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        clearDebounce();
+        searchIdps(usernameInput.value);
+      }
+    });
+
     usernameInput.addEventListener('input', function (e) {
       nextButton.disabled = !e.target.value;
       debouncedSearchIdps(e.target.value);


### PR DESCRIPTION
## Jira task - [AUT-8441](https://cloudentity.atlassian.net/browse/AUT-8441)

## Release Notes Description

Fixes an issue where on login form, pressing enter key after typing in identifier bypassed domain discovery, potentially resulting in redirect to wrong IDP

[AUT-8441]: https://cloudentity.atlassian.net/browse/AUT-8441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ