### PR TITLE
Fix template bug

### DIFF
--- a/theme/pages/identity/login/authn_mode_otp_verify.tmpl
+++ b/theme/pages/identity/login/authn_mode_otp_verify.tmpl
@@ -65,7 +65,7 @@
         (and (eq .Data.OtpMode "email") (or (eq .Data.UserID "") (gt (len .Data.UserEmails) 1)))
         (and (eq .Data.OtpMode "sms") (or (eq .Data.UserID "") (gt (len .Data.UserMobiles) 1)))
     -}}
-    {{- $hasErrors := eq (len .Data.FormError.Errors) 0 -}}
+    {{- $hasErrors := gt (len .Data.FormError.Errors) 0 -}}
 
     {{ if or $hasErrors $showAlternativeButton }}
         <div class="notification-container" id="code-sent-notification">


### PR DESCRIPTION
In OTP verification screen, there is a bool condition which is checking if there is a error, but its effectively inversed so it never shows a error